### PR TITLE
fix: [#102] Restore SMTP mail delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,9 +282,16 @@ We are currently using the following ENV variables:
 * `S3_ACCESS_KEY_ID` - active storage S3 access key
 * `S3_SECRET_ACCESS_KEY` - active storage S3 secret access key
 * `SMTP_ADDRESS` - smtp mail server address
+* `SMTP_PORT` (Optional) - smtp mail server port (default `587`)
 * `SMTP_USERNAME` - smtp user name or email address
 * `SMTP_PASSWORD` - smtp password
+* `SMTP_AUTHENTICATION` (Optional) - smtp authentication method (default `plain`)
+* `SMTP_STARTTLS` (Optional) - enable automatic STARTTLS (default `true`)
 * `FROM_EMAIL` - from email (if not set `from@example.com` will be used)
+
+The legacy `SMPT_ADDRESS`, `SMPT_USERNAME`, and `SMPT_PASSWORD` names remain supported as fallbacks. New
+deployments should use the documented `SMTP_*` names.
+
 * `GOOGLE_ANALYTICS` - google analytics key for GMT (if present than analytics
   script is added into head section)
 * `PORTAL_BASE_URL` - portal base URL used to generate footer and other static

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -127,13 +127,17 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
 
   # SMTP settings
+  smtp_address = ENV.fetch("SMTP_ADDRESS", nil).presence || ENV.fetch("SMPT_ADDRESS", nil)
+  smtp_username = ENV.fetch("SMTP_USERNAME", nil).presence || ENV.fetch("SMPT_USERNAME", nil)
+  smtp_password = ENV.fetch("SMTP_PASSWORD", nil).presence || ENV.fetch("SMPT_PASSWORD", nil)
+
   config.action_mailer.smtp_settings = {
-      address: ENV.fetch("SMPT_ADDRESS", nil),
-      port: ENV.fetch("SMTP_PORT", 587),
-      user_name: ENV.fetch("SMPT_USERNAME", nil),
-      password: ENV.fetch("SMPT_PASSWORD", nil),
-      authentication: ENV.fetch("SMTP_AUTHENTICATION", "plain"),
-      enable_starttls_auto: ENV.fetch("SMTP_STARTTLS", true)
+    address: smtp_address,
+    port: ENV.fetch("SMTP_PORT", 587).to_i,
+    user_name: smtp_username,
+    password: smtp_password,
+    authentication: ENV.fetch("SMTP_AUTHENTICATION", "plain"),
+    enable_starttls_auto: ActiveModel::Type::Boolean.new.cast(ENV.fetch("SMTP_STARTTLS", true))
   }
 
   # custom error pages with webpage layout

--- a/spec/config/environments/production_spec.rb
+++ b/spec/config/environments/production_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "open3"
+
+RSpec.describe "Production environment", backend: true do
+  let(:base_environment) do
+    {
+      "RAILS_ENV" => "production",
+      "SECRET_KEY_BASE_DUMMY" => "1",
+      "ROOT_URL" => "https://marketplace.example.org",
+      "SMTP_ADDRESS" => nil,
+      "SMTP_PORT" => nil,
+      "SMTP_USERNAME" => nil,
+      "SMTP_PASSWORD" => nil,
+      "SMTP_AUTHENTICATION" => nil,
+      "SMTP_STARTTLS" => nil,
+      "SMPT_ADDRESS" => nil,
+      "SMPT_USERNAME" => nil,
+      "SMPT_PASSWORD" => nil
+    }
+  end
+  let(:configuration_script) { <<~RUBY }
+      require "json"
+      require_relative "config/application"
+      require_relative "config/environments/production"
+
+      settings = Rails.application.config.action_mailer.smtp_settings
+      puts JSON.generate(settings.slice(:address, :port, :user_name, :password, :authentication,
+                                        :enable_starttls_auto))
+    RUBY
+
+  def load_smtp_settings(environment)
+    stdout, stderr, status =
+      Open3.capture3(environment, RbConfig.ruby, "-e", configuration_script, chdir: Rails.root.to_s)
+
+    expect(status).to be_success, stderr
+
+    JSON.parse(stdout, symbolize_names: true)
+  end
+
+  it "loads SMTP settings from the documented environment variables" do
+    environment =
+      base_environment.merge(
+        "SMTP_ADDRESS" => "smtp.example.org",
+        "SMTP_PORT" => "2525",
+        "SMTP_USERNAME" => "mailer",
+        "SMTP_PASSWORD" => "secret",
+        "SMTP_AUTHENTICATION" => "login",
+        "SMTP_STARTTLS" => "false",
+        "SMPT_ADDRESS" => "legacy-smtp.example.org",
+        "SMPT_USERNAME" => "legacy-mailer",
+        "SMPT_PASSWORD" => "legacy-secret"
+      )
+
+    expect(load_smtp_settings(environment)).to eq(
+      address: "smtp.example.org",
+      port: 2525,
+      user_name: "mailer",
+      password: "secret",
+      authentication: "login",
+      enable_starttls_auto: false
+    )
+  end
+
+  it "supports the legacy misspelled credential variables" do
+    environment =
+      base_environment.merge(
+        "SMPT_ADDRESS" => "legacy-smtp.example.org",
+        "SMPT_USERNAME" => "legacy-mailer",
+        "SMPT_PASSWORD" => "legacy-secret"
+      )
+
+    expect(load_smtp_settings(environment)).to eq(
+      address: "legacy-smtp.example.org",
+      port: 587,
+      user_name: "legacy-mailer",
+      password: "legacy-secret",
+      authentication: "plain",
+      enable_starttls_auto: true
+    )
+  end
+end


### PR DESCRIPTION
## Summary

- read the documented SMTP_ADDRESS, SMTP_USERNAME, and SMTP_PASSWORD variables in production
- retain the legacy SMPT credential names as fallbacks, with canonical SMTP names taking precedence
- convert SMTP_PORT and SMTP_STARTTLS to the types expected by the Mail transport
- document all production SMTP options and cover the loaded production configuration

## Why mail delivery failed

Production read the misspelled SMPT credential variables even though this repository documents SMTP names. A deployment following the README therefore supplied values that Action Mailer never received. In addition, an SMTP_STARTTLS environment value arrived as a string, while the locked Mail 2.8.1 transport accepts only true, false, or nil.

## How Marketplace mail works

@alicjaswieradcyfronet @agpul

1. Domain actions invoke ServiceMailer, ProviderMailer, ProjectItemMailer, OfferMailer, or MessageMailer and call deliver_later.
2. Active Job uses Sidekiq outside the test environment and enqueues Action Mailer jobs in Redis on the mailers queue.
3. The Sidekiq worker consumes that queue, renders the HTML and text templates through ApplicationMailer, applies FROM_EMAIL, and passes the message to the configured SMTP relay.

The current notification families cover service and provider questions, new-service subscriptions, order and project-item lifecycle changes, offer availability and bundle changes, and project or order conversations. Content and recipient improvements can be made in the corresponding mailer and templates without changing this transport path.

## Verification

- bundle exec rspec spec/config/environments/production_spec.rb spec/mailers spec/services/service/publish_spec.rb (23 examples, 0 failures)
- bundle exec rubocop config/environments/production.rb spec/config/environments/production_spec.rb
- bundle exec rbprettier --check config/environments/production.rb spec/config/environments/production_spec.rb
- production config smoke check with fake credentials, including Mail STARTTLS session construction without a network connection

Browser mail scenarios were attempted locally, but Chrome 150 could not start with the installed ChromeDriver 147. CI should exercise them with its pinned browser environment.

## Rollout

- provide SMTP_ADDRESS, SMTP_USERNAME, SMTP_PASSWORD, and FROM_EMAIL to both web and Sidekiq worker processes
- restart both processes after changing the environment
- send one staging notification, confirm the Sidekiq mailers job succeeds, and verify inbox receipt

Closes #102